### PR TITLE
fix: address code review findings

### DIFF
--- a/goga/commands/CODEMANIFEST
+++ b/goga/commands/CODEMANIFEST
@@ -3,15 +3,10 @@ Imports:
       - AST
     From: goga/ast
   - Types:
-      - python_contract
-      - golang_contract
+      - contract AS contract_logic
+    Usages:
+      - contract AS use_contract
     From: goga/contract
-  - Usages:
-      - golang_contract AS use_go_contract
-    From: goga/contract/golang
-  - Usages:
-      - python_contract AS use_py_contract
-    From: goga/contract/python
   - Types:
       - Config
       - load_config
@@ -151,8 +146,8 @@ Annotations: |
 "contract(cells: list[str], lang: str | None = None)":
   location: contract.py
   annotations: |
-    При загрузке контрактов используй `use_py_contract` и `use_go_contract` практики
     Команда сравнения контракта CODEMANIFEST с реализацией.
+    Использовать практику `use_contract` для понимания работы диспатчера контрактов.
 
     `cells`: пути к клеткам для сравнения, один или несколько
     `lang`: язык реализации. Приоритет: CLI-аргумент > `Config`. Если None — берётся из `Config`.lang
@@ -165,15 +160,11 @@ Annotations: |
     2. Разрешить язык:
        - Если `lang` передан (не None) — использовать CLI значение
        - Иначе — использовать `Config`.lang
-    3. Диспетчеризация по языку:
-       - "python" → использовать `python_contract`
-       - "golang" → использовать `golang_contract`
-       - неизвестный язык → ошибка
-    4. Создать и загрузить проект с использованием практики `documents`
-    5. Для каждого пути из `cells`:
+    3. Создать и загрузить проект с использованием практики `documents`
+    4. Для каждого пути из `cells`:
       - Найти документ в дереве с использованием практики `documents`
       - Извлечь типы из body документа: entities и routines
-      - Получить реализованный контракт через выбранную языковую практику
+      - Получить реализованный контракт через `contract_logic`
       - Для каждого типа из CODEMANIFEST найти соответствие в реализации по имени
       - Построить структуру сравнения (CODEMANIFEST первичен)
 

--- a/goga/commands/contract.py
+++ b/goga/commands/contract.py
@@ -15,8 +15,9 @@ from ..contract import (
     MethodContract,
     PropertyContract,
     RoutineContract,
-    golang_contract,
-    python_contract,
+)
+from ..contract import (
+    contract as contract_logic,
 )
 
 if TYPE_CHECKING:
@@ -121,21 +122,6 @@ def contract(ctx: click.Context, cells: tuple[str, ...], lang: str | None) -> No
 
     lang = lang if lang is not None else config.lang
 
-    if lang == "golang" and golang_contract is None:
-        click.echo("Error: golang support not available (tree-sitter not installed)", err=True)
-        ctx.exit(1)
-        return
-
-    dispatch = {
-        "python": python_contract,
-        "golang": golang_contract,
-    }
-    contract_fn = dispatch.get(lang)
-    if contract_fn is None:
-        click.echo(f"Error: unsupported language: {lang}", err=True)
-        ctx.exit(1)
-        return
-
     ast_obj = AST(".")
     ast_obj.load()
 
@@ -148,7 +134,7 @@ def contract(ctx: click.Context, cells: tuple[str, ...], lang: str | None) -> No
             ctx.exit(1)
 
         try:
-            impl_contracts = contract_fn(cell_path)
+            impl_contracts = contract_logic(lang, cell_path)
         except ModuleNotFoundError:
             click.echo(f"Error: package not importable: {cell_path}", err=True)
             ctx.exit(1)

--- a/goga/contract/.usages/contract.md
+++ b/goga/contract/.usages/contract.md
@@ -1,0 +1,10 @@
+Диспетчер контрактных операций по языку реализации.
+
+```python
+from goga.contract import contract
+
+result = contract("python", "path/to/cell")
+# result: list[goga.contract.EntityContract | goga.contract.RoutineContract]
+```
+
+Язык передаётся строкой: "python", "golang". При неизвестном языке — ValueError.

--- a/goga/contract/CODEMANIFEST
+++ b/goga/contract/CODEMANIFEST
@@ -7,17 +7,21 @@ Imports:
     From: goga/contract/data
   - Types:
       - python_contract
+    Usages:
+      - python_contract AS use_py_contract
     From: goga/contract/python
   - Types:
       - golang_contract
+    Usages:
+      - golang_contract AS use_go_contract
     From: goga/contract/golang
 
 Usages:
-  conventions: .goga/usages/development/conventions.md
+  convention: .goga/usages/development/conventions.md
 
 Annotations: |
-  При разработке и тестировании использовать практику `conventions`.
-  Клетка — фасад для всех контрактных операций
+  При разработке и тестировании использовать практику `convention`.
+  Клетка — фасад для всех контрактных операций.
 
 ---
 
@@ -25,13 +29,24 @@ Annotations: |
 ->RoutineContract: {}
 ->PropertyContract: {}
 ->MethodContract: {}
-->python_contract: {}
-->golang_contract: {}
+
+"contract(lang: str, cell_path: str) -> contracts:list[EntityContract | RoutineContract]":
+  location: dispatcher.py
+  annotations: |
+    Диспетчер контрактных операций по языку реализации.
+
+    `lang`: язык реализации ("python", "golang")
+    `cell_path`: путь до ячейки
+
+    Алгоритм:
+    - "python" → вызвать `python_contract`(`cell_path`), использовать практику `use_py_contract`
+    - "golang" → вызвать `golang_contract`(`cell_path`), использовать практику `use_go_contract`
+    - неизвестный язык → ValueError
 
 ---
 
 Author: Goga
-CreatedAt: 19/05/26
+CreatedAt: 20/05/26
 
 Description: |
   Работа с реализованным контрактом в языке программирования

--- a/goga/contract/__init__.py
+++ b/goga/contract/__init__.py
@@ -5,6 +5,7 @@ from goga.contract.data import (
     PropertyContract,
     RoutineContract,
 )
+from goga.contract.dispatcher import contract
 from goga.contract.python import python_contract
 
 try:
@@ -18,6 +19,7 @@ __all__ = [
     "MethodContract",
     "PropertyContract",
     "RoutineContract",
+    "contract",
     "golang_contract",
     "python_contract",
 ]

--- a/goga/contract/dispatcher.py
+++ b/goga/contract/dispatcher.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+# ruff: noqa: PLC0415 — lazy imports required by contract
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from goga.contract.data import EntityContract, RoutineContract
+
+
+def contract(lang: str, cell_path: str) -> list[EntityContract | RoutineContract]:
+    if lang == "python":
+        from .python import python_contract
+
+        return python_contract(cell_path)
+    if lang == "golang":
+        from .golang import golang_contract
+
+        return golang_contract(cell_path)
+    raise ValueError(f"unsupported language: {lang}")

--- a/tests/commands/test_contract.py
+++ b/tests/commands/test_contract.py
@@ -1,0 +1,177 @@
+"""Contract and behavioral tests for contract CLI command."""
+
+import json
+import sys
+from pathlib import Path
+from unittest import mock
+
+import click
+from click.testing import CliRunner
+from goga.commands.contract import contract
+from goga.config.config import BuildConfig, Config, TaskExecutor
+
+
+def _make_config(lang: str = "python") -> Config:
+    return Config(
+        lang=lang,
+        build=BuildConfig(task_executor=TaskExecutor(agent="claude")),
+    )
+
+
+# ── Contract tests ──────────────────────────────────────────
+
+
+class TestContract:
+    """Contract-level tests for contract command."""
+
+    def test_contract_importable_from_facade(self) -> None:
+        from goga.commands import contract as facade_contract
+
+        assert facade_contract is contract
+
+    def test_contract_is_click_command(self) -> None:
+        assert isinstance(contract, click.Command)
+
+    def test_contract_accepts_variadic_cells_and_lang(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(contract, ["--help"])
+        assert result.exit_code == 0
+        assert "CELLS" in result.output or "cells" in result.output
+        assert "--lang" in result.output
+
+
+# ── Behavioral tests ────────────────────────────────────────
+
+
+class TestBehavioral:
+    """Behavioral tests for contract command."""
+
+    def test_command_contract_with_dispatcher(self, tmp_path: Path) -> None:
+        """CLI delegates through contract_logic for python."""
+        # Create a minimal Python package
+        pkg_dir = tmp_path / "mypkg"
+        pkg_dir.mkdir()
+        (pkg_dir / "__init__.py").write_text(
+            "class MyService:\n"
+            "    def run(self) -> str:\n"
+            "        return ''\n"
+            "\n"
+            "__all__ = ['MyService']\n"
+        )
+        sys.path.insert(0, str(tmp_path))
+        try:
+            cfg = _make_config("python")
+            runner = CliRunner()
+            with (
+                mock.patch("goga.commands.contract.load_config", return_value=cfg),
+                mock.patch("goga.commands.contract.AST") as mock_ast_cls,
+            ):
+                # Setup AST mock
+                mock_ast = mock.MagicMock()
+                mock_ast_cls.return_value = mock_ast
+                mock_doc = mock.MagicMock()
+                mock_doc.path = "mypkg"
+                mock_entity = mock.MagicMock()
+                mock_entity.name = "MyService"
+                mock_entity.signature = "class MyService"
+                mock_entity.properties = []
+                mock_method = mock.MagicMock()
+                mock_method.name = "run"
+                mock_method.signature = "def run(self) -> str"
+                mock_entity.methods = [mock_method]
+                mock_doc.body.entities = [mock_entity]
+                mock_doc.body.routines = []
+                mock_ast.document.return_value = mock_doc
+
+                result = runner.invoke(contract, ["mypkg"])
+        finally:
+            sys.path.remove(str(tmp_path))
+            sys.modules.pop("mypkg", None)
+
+        assert result.exit_code == 0
+        output = json.loads(result.output)
+        assert "mypkg" in output
+        assert "MyService" in output["mypkg"]
+
+    def test_command_contract_unsupported_language(self, tmp_path: Path) -> None:
+        """Unsupported language triggers stderr and exit 1."""
+        cfg = _make_config("rust")
+        runner = CliRunner()
+        with (
+            mock.patch("goga.commands.contract.load_config", return_value=cfg),
+            mock.patch("goga.commands.contract.AST") as mock_ast_cls,
+        ):
+            mock_ast = mock.MagicMock()
+            mock_ast_cls.return_value = mock_ast
+            mock_doc = mock.MagicMock()
+            mock_doc.path = "goga/cell"
+            mock_doc.body.entities = []
+            mock_doc.body.routines = []
+            mock_ast.document.return_value = mock_doc
+
+            result = runner.invoke(contract, ["--lang", "rust", "goga/cell"])
+
+        assert result.exit_code == 1
+        assert "unsupported language" in result.output
+
+    def test_command_contract_empty_cells_tuple(self, tmp_path: Path) -> None:
+        """Empty cells tuple produces empty JSON object."""
+        cfg = _make_config("python")
+        runner = CliRunner()
+        with (
+            mock.patch("goga.commands.contract.load_config", return_value=cfg),
+            mock.patch("goga.commands.contract.AST") as mock_ast_cls,
+        ):
+            mock_ast = mock.MagicMock()
+            mock_ast_cls.return_value = mock_ast
+            mock_ast.load.return_value = None
+
+            result = runner.invoke(contract, [])
+
+        assert result.exit_code == 0
+        assert json.loads(result.output) == {}
+
+    def test_command_contract_module_not_found(self, tmp_path: Path) -> None:
+        """Missing cell module produces exit 1 and error message."""
+        cfg = _make_config("python")
+        runner = CliRunner()
+        with (
+            mock.patch("goga.commands.contract.load_config", return_value=cfg),
+            mock.patch("goga.commands.contract.AST") as mock_ast_cls,
+        ):
+            mock_ast = mock.MagicMock()
+            mock_ast_cls.return_value = mock_ast
+            mock_doc = mock.MagicMock()
+            mock_doc.path = "nonexistent"
+            mock_entity = mock.MagicMock()
+            mock_entity.name = "Foo"
+            mock_entity.signature = "class Foo"
+            mock_entity.properties = []
+            mock_entity.methods = []
+            mock_doc.body.entities = [mock_entity]
+            mock_doc.body.routines = []
+            mock_ast.document.return_value = mock_doc
+
+            result = runner.invoke(contract, ["nonexistent"])
+
+        assert result.exit_code == 1
+        assert "package not importable" in result.output
+
+    def test_command_contract_document_not_found(self, tmp_path: Path) -> None:
+        """DocumentNotFoundError from AST produces exit 1 and error message."""
+        from goga.ast.errors import DocumentNotFoundError
+
+        cfg = _make_config("python")
+        runner = CliRunner()
+        with (
+            mock.patch("goga.commands.contract.load_config", return_value=cfg),
+            mock.patch("goga.commands.contract.AST") as mock_ast_cls,
+        ):
+            mock_ast = mock.MagicMock()
+            mock_ast_cls.return_value = mock_ast
+            mock_ast.document.side_effect = DocumentNotFoundError("missing_cell")
+
+            result = runner.invoke(contract, ["missing_cell"])
+
+        assert result.exit_code == 1
+        assert "document not found" in result.output

--- a/tests/commands/test_contract.py
+++ b/tests/commands/test_contract.py
@@ -10,6 +10,8 @@ from click.testing import CliRunner
 from goga.commands.contract import contract
 from goga.config.config import BuildConfig, Config, TaskExecutor
 
+_contract_mod = sys.modules["goga.commands.contract"]
+
 
 def _make_config(lang: str = "python") -> Config:
     return Config(
@@ -63,8 +65,8 @@ class TestBehavioral:
             cfg = _make_config("python")
             runner = CliRunner()
             with (
-                mock.patch("goga.commands.contract.load_config", return_value=cfg),
-                mock.patch("goga.commands.contract.AST") as mock_ast_cls,
+                mock.patch.object(_contract_mod, "load_config", return_value=cfg),
+                mock.patch.object(_contract_mod, "AST") as mock_ast_cls,
             ):
                 # Setup AST mock
                 mock_ast = mock.MagicMock()
@@ -98,8 +100,8 @@ class TestBehavioral:
         cfg = _make_config("rust")
         runner = CliRunner()
         with (
-            mock.patch("goga.commands.contract.load_config", return_value=cfg),
-            mock.patch("goga.commands.contract.AST") as mock_ast_cls,
+            mock.patch.object(_contract_mod, "load_config", return_value=cfg),
+            mock.patch.object(_contract_mod, "AST") as mock_ast_cls,
         ):
             mock_ast = mock.MagicMock()
             mock_ast_cls.return_value = mock_ast
@@ -119,8 +121,8 @@ class TestBehavioral:
         cfg = _make_config("python")
         runner = CliRunner()
         with (
-            mock.patch("goga.commands.contract.load_config", return_value=cfg),
-            mock.patch("goga.commands.contract.AST") as mock_ast_cls,
+            mock.patch.object(_contract_mod, "load_config", return_value=cfg),
+            mock.patch.object(_contract_mod, "AST") as mock_ast_cls,
         ):
             mock_ast = mock.MagicMock()
             mock_ast_cls.return_value = mock_ast
@@ -136,8 +138,8 @@ class TestBehavioral:
         cfg = _make_config("python")
         runner = CliRunner()
         with (
-            mock.patch("goga.commands.contract.load_config", return_value=cfg),
-            mock.patch("goga.commands.contract.AST") as mock_ast_cls,
+            mock.patch.object(_contract_mod, "load_config", return_value=cfg),
+            mock.patch.object(_contract_mod, "AST") as mock_ast_cls,
         ):
             mock_ast = mock.MagicMock()
             mock_ast_cls.return_value = mock_ast
@@ -164,8 +166,8 @@ class TestBehavioral:
         cfg = _make_config("python")
         runner = CliRunner()
         with (
-            mock.patch("goga.commands.contract.load_config", return_value=cfg),
-            mock.patch("goga.commands.contract.AST") as mock_ast_cls,
+            mock.patch.object(_contract_mod, "load_config", return_value=cfg),
+            mock.patch.object(_contract_mod, "AST") as mock_ast_cls,
         ):
             mock_ast = mock.MagicMock()
             mock_ast_cls.return_value = mock_ast

--- a/tests/contract/test_integration.py
+++ b/tests/contract/test_integration.py
@@ -11,6 +11,8 @@ from goga.commands.contract import contract
 from goga.config.config import BuildConfig, Config, TaskExecutor
 from goga.contract import EntityContract, RoutineContract, python_contract
 
+_contract_mod = sys.modules["goga.commands.contract"]
+
 
 def _make_config(lang: str = "python") -> Config:
     return Config(
@@ -122,8 +124,8 @@ class TestEndToEndPython:
             cfg = _make_config("python")
             runner = CliRunner()
             with (
-                mock.patch("goga.commands.contract.load_config", return_value=cfg),
-                mock.patch("goga.commands.contract.AST") as mock_ast_cls,
+                mock.patch.object(_contract_mod, "load_config", return_value=cfg),
+                mock.patch.object(_contract_mod, "AST") as mock_ast_cls,
             ):
                 mock_ast = mock.MagicMock()
                 mock_ast_cls.return_value = mock_ast
@@ -182,8 +184,8 @@ class TestEndToEndGolang:
         cfg = _make_config("golang")
         runner = CliRunner()
         with (
-            mock.patch("goga.commands.contract.load_config", return_value=cfg),
-            mock.patch("goga.commands.contract.AST") as mock_ast_cls,
+            mock.patch.object(_contract_mod, "load_config", return_value=cfg),
+            mock.patch.object(_contract_mod, "AST") as mock_ast_cls,
         ):
             mock_ast = mock.MagicMock()
             mock_ast_cls.return_value = mock_ast
@@ -225,8 +227,8 @@ class TestMultipleCells:
             cfg = _make_config("python")
             runner = CliRunner()
             with (
-                mock.patch("goga.commands.contract.load_config", return_value=cfg),
-                mock.patch("goga.commands.contract.AST") as mock_ast_cls,
+                mock.patch.object(_contract_mod, "load_config", return_value=cfg),
+                mock.patch.object(_contract_mod, "AST") as mock_ast_cls,
             ):
                 mock_ast = mock.MagicMock()
                 mock_ast_cls.return_value = mock_ast
@@ -264,8 +266,8 @@ class TestErrorPropagation:
         cfg = _make_config("rust")
         runner = CliRunner()
         with (
-            mock.patch("goga.commands.contract.load_config", return_value=cfg),
-            mock.patch("goga.commands.contract.AST") as mock_ast_cls,
+            mock.patch.object(_contract_mod, "load_config", return_value=cfg),
+            mock.patch.object(_contract_mod, "AST") as mock_ast_cls,
         ):
             mock_ast = mock.MagicMock()
             mock_ast_cls.return_value = mock_ast
@@ -284,8 +286,8 @@ class TestErrorPropagation:
         cfg = _make_config("python")
         runner = CliRunner()
         with (
-            mock.patch("goga.commands.contract.load_config", return_value=cfg),
-            mock.patch("goga.commands.contract.AST") as mock_ast_cls,
+            mock.patch.object(_contract_mod, "load_config", return_value=cfg),
+            mock.patch.object(_contract_mod, "AST") as mock_ast_cls,
         ):
             mock_ast = mock.MagicMock()
             mock_ast_cls.return_value = mock_ast

--- a/tests/contract/test_integration.py
+++ b/tests/contract/test_integration.py
@@ -1,8 +1,22 @@
 """Integration tests for goga.contract package."""
 
 import json
+import sys
+from pathlib import Path
+from unittest import mock
 
+import pytest
+from click.testing import CliRunner
+from goga.commands.contract import contract
+from goga.config.config import BuildConfig, Config, TaskExecutor
 from goga.contract import EntityContract, RoutineContract, python_contract
+
+
+def _make_config(lang: str = "python") -> Config:
+    return Config(
+        lang=lang,
+        build=BuildConfig(task_executor=TaskExecutor(agent="claude")),
+    )
 
 
 class TestSelfReference:
@@ -88,3 +102,205 @@ class TestSignatureFormatMatchesContractFormat:
         serialized = json.dumps(data)
         parsed = json.loads(serialized)
         assert parsed == data
+
+
+class TestEndToEndPython:
+    """End-to-end: CLI -> contract_logic dispatcher -> python_contract."""
+
+    def test_python_e2e_produces_codemanifest_implementation_pairs(self, tmp_path: Path) -> None:
+        pkg_dir = tmp_path / "cellpy"
+        pkg_dir.mkdir()
+        (pkg_dir / "__init__.py").write_text(
+            "class CellService:\n"
+            "    def execute(self) -> str:\n"
+            "        return ''\n"
+            "\n"
+            "__all__ = ['CellService']\n"
+        )
+        sys.path.insert(0, str(tmp_path))
+        try:
+            cfg = _make_config("python")
+            runner = CliRunner()
+            with (
+                mock.patch("goga.commands.contract.load_config", return_value=cfg),
+                mock.patch("goga.commands.contract.AST") as mock_ast_cls,
+            ):
+                mock_ast = mock.MagicMock()
+                mock_ast_cls.return_value = mock_ast
+                mock_doc = mock.MagicMock()
+                mock_doc.path = "cellpy"
+                mock_entity = mock.MagicMock()
+                mock_entity.name = "CellService"
+                mock_entity.signature = "class CellService"
+                mock_entity.properties = []
+                mock_method = mock.MagicMock()
+                mock_method.name = "execute"
+                mock_method.signature = "def execute(self) -> str"
+                mock_entity.methods = [mock_method]
+                mock_doc.body.entities = [mock_entity]
+                mock_doc.body.routines = []
+                mock_ast.document.return_value = mock_doc
+
+                result = runner.invoke(contract, ["cellpy"])
+        finally:
+            sys.path.remove(str(tmp_path))
+            sys.modules.pop("cellpy", None)
+
+        assert result.exit_code == 0
+        output = json.loads(result.output)
+        assert "cellpy" in output
+        svc = output["cellpy"]["CellService"]
+        assert "codemanifest" in svc["signature"]
+        assert "implementation" in svc["signature"]
+        assert "execute" in svc["methods"]
+        assert "codemanifest" in svc["methods"]["execute"]
+        assert "implementation" in svc["methods"]["execute"]
+
+
+def _golang_available() -> bool:
+    try:
+        import tree_sitter_go  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
+class TestEndToEndGolang:
+    """End-to-end: CLI -> contract_logic dispatcher -> golang_contract."""
+
+    @pytest.mark.skipif(
+        not _golang_available(),
+        reason="tree-sitter-go not installed",
+    )
+    def test_golang_e2e_produces_routine_contract(self, tmp_path: Path) -> None:
+        go_dir = tmp_path / "cellgo"
+        go_dir.mkdir()
+        (go_dir / "example.go").write_text(
+            'package cellgo\n\nfunc Hello(name string) string { return "" }\n'
+        )
+        cfg = _make_config("golang")
+        runner = CliRunner()
+        with (
+            mock.patch("goga.commands.contract.load_config", return_value=cfg),
+            mock.patch("goga.commands.contract.AST") as mock_ast_cls,
+        ):
+            mock_ast = mock.MagicMock()
+            mock_ast_cls.return_value = mock_ast
+            mock_doc = mock.MagicMock()
+            mock_doc.path = "cellgo"
+            mock_routine = mock.MagicMock()
+            mock_routine.name = "Hello"
+            mock_routine.signature = "func Hello(name string) string"
+            mock_doc.body.entities = []
+            mock_doc.body.routines = [mock_routine]
+            mock_ast.document.return_value = mock_doc
+
+            result = runner.invoke(contract, ["--lang", "golang", str(go_dir)])
+
+        assert result.exit_code == 0
+        output = json.loads(result.output)
+        assert "cellgo" in output
+        assert "Hello" in output["cellgo"]
+        assert "codemanifest" in output["cellgo"]["Hello"]["signature"]
+        assert "implementation" in output["cellgo"]["Hello"]["signature"]
+
+
+class TestMultipleCells:
+    """Multiple cell paths in a single CLI invocation."""
+
+    def test_multiple_cells_produces_entries_for_each(self, tmp_path: Path) -> None:
+        pkg_a = tmp_path / "cell_a"
+        pkg_a.mkdir()
+        (pkg_a / "__init__.py").write_text(
+            "class ServiceA:\n    pass\n\n__all__ = ['ServiceA']\n"
+        )
+        pkg_b = tmp_path / "cell_b"
+        pkg_b.mkdir()
+        (pkg_b / "__init__.py").write_text(
+            "class ServiceB:\n    pass\n\n__all__ = ['ServiceB']\n"
+        )
+        sys.path.insert(0, str(tmp_path))
+        try:
+            cfg = _make_config("python")
+            runner = CliRunner()
+            with (
+                mock.patch("goga.commands.contract.load_config", return_value=cfg),
+                mock.patch("goga.commands.contract.AST") as mock_ast_cls,
+            ):
+                mock_ast = mock.MagicMock()
+                mock_ast_cls.return_value = mock_ast
+
+                def make_doc(name: str) -> mock.MagicMock:
+                    doc = mock.MagicMock()
+                    doc.path = name
+                    entity = mock.MagicMock()
+                    entity.name = name.replace("_", "").title() + "Service"
+                    entity.signature = f"class {entity.name}"
+                    entity.properties = []
+                    entity.methods = []
+                    doc.body.entities = [entity]
+                    doc.body.routines = []
+                    return doc
+
+                mock_ast.document.side_effect = make_doc
+
+                result = runner.invoke(contract, ["cell_a", "cell_b"])
+        finally:
+            sys.path.remove(str(tmp_path))
+            sys.modules.pop("cell_a", None)
+            sys.modules.pop("cell_b", None)
+
+        assert result.exit_code == 0
+        output = json.loads(result.output)
+        assert "cell_a" in output
+        assert "cell_b" in output
+
+
+class TestErrorPropagation:
+    """Errors propagate correctly through the full chain: dispatcher -> CLI."""
+
+    def test_unsupported_language_stderr_exit1(self) -> None:
+        cfg = _make_config("rust")
+        runner = CliRunner()
+        with (
+            mock.patch("goga.commands.contract.load_config", return_value=cfg),
+            mock.patch("goga.commands.contract.AST") as mock_ast_cls,
+        ):
+            mock_ast = mock.MagicMock()
+            mock_ast_cls.return_value = mock_ast
+            mock_doc = mock.MagicMock()
+            mock_doc.path = "some_cell"
+            mock_doc.body.entities = []
+            mock_doc.body.routines = []
+            mock_ast.document.return_value = mock_doc
+
+            result = runner.invoke(contract, ["--lang", "rust", "some_cell"])
+
+        assert result.exit_code == 1
+        assert "unsupported language" in result.output
+
+    def test_module_not_found_stderr_exit1(self) -> None:
+        cfg = _make_config("python")
+        runner = CliRunner()
+        with (
+            mock.patch("goga.commands.contract.load_config", return_value=cfg),
+            mock.patch("goga.commands.contract.AST") as mock_ast_cls,
+        ):
+            mock_ast = mock.MagicMock()
+            mock_ast_cls.return_value = mock_ast
+            mock_doc = mock.MagicMock()
+            mock_doc.path = "nonexistent_pkg"
+            mock_entity = mock.MagicMock()
+            mock_entity.name = "Ghost"
+            mock_entity.signature = "class Ghost"
+            mock_entity.properties = []
+            mock_entity.methods = []
+            mock_doc.body.entities = [mock_entity]
+            mock_doc.body.routines = []
+            mock_ast.document.return_value = mock_doc
+
+            result = runner.invoke(contract, ["nonexistent_pkg"])
+
+        assert result.exit_code == 1
+        assert "package not importable" in result.output

--- a/tests/goga/contract/test_dispatcher.py
+++ b/tests/goga/contract/test_dispatcher.py
@@ -1,0 +1,96 @@
+"""Contract and behavioral tests for contract() dispatcher."""
+
+import inspect
+import sys
+from pathlib import Path
+
+import pytest
+from goga.contract import contract
+from goga.contract.data import EntityContract, RoutineContract
+
+# ── Contract tests ──────────────────────────────────────────
+
+
+def test_contract_importable_from_facade():
+    """contract is importable from goga.contract facade."""
+    from goga.contract import contract as c
+
+    assert callable(c)
+
+
+def test_contract_signature():
+    """contract has signature (lang: str, cell_path: str) -> list[EntityContract | RoutineContract]."""
+    sig = inspect.signature(contract)
+    params = list(sig.parameters.keys())
+    assert params == ["lang", "cell_path"]
+    assert sig.parameters["lang"].annotation in (str, "str")
+    assert sig.parameters["cell_path"].annotation in (str, "str")
+    ret = sig.return_annotation
+    assert ret == "list[EntityContract | RoutineContract]"
+
+
+# ── Behavioral tests ────────────────────────────────────────
+
+
+def test_contract_dispatches_to_python(tmp_path: Path) -> None:
+    """Dispatching to python_contract returns correct EntityContract."""
+    pkg_dir = tmp_path / "cell"
+    pkg_dir.mkdir()
+    (pkg_dir / "__init__.py").write_text(
+        "class MyClass:\n"
+        "    def my_method(self) -> str:\n"
+        "        return ''\n"
+        "\n"
+        "__all__ = ['MyClass']\n"
+    )
+    parent = str(tmp_path)
+    sys.path.insert(0, parent)
+    try:
+        result = contract("python", "cell")
+        assert len(result) >= 1
+        entities = [r for r in result if isinstance(r, EntityContract) and r.name == "MyClass"]
+        assert len(entities) == 1
+        methods = [m for m in entities[0].methods if m.name == "my_method"]
+        assert len(methods) == 1
+    finally:
+        sys.path.remove(parent)
+        sys.modules.pop("cell", None)
+
+
+def test_contract_dispatches_to_golang(tmp_path: Path) -> None:
+    """Dispatching to golang_contract returns correct RoutineContract."""
+    pytest.importorskip("tree_sitter_go", reason="tree-sitter-go not installed")
+    go_dir = tmp_path / "cell"
+    go_dir.mkdir()
+    (go_dir / "example.go").write_text(
+        'package cell\n\nfunc Hello(name string) string { return "" }\n'
+    )
+    result = contract("golang", str(go_dir))
+    routines = [r for r in result if isinstance(r, RoutineContract) and r.name == "Hello"]
+    assert len(routines) >= 1
+
+
+def test_contract_unsupported_language() -> None:
+    """Unknown language raises ValueError."""
+    with pytest.raises(ValueError, match="unsupported language"):
+        contract("rust", "some/path")
+
+
+def test_contract_empty_language() -> None:
+    """Empty language string raises ValueError."""
+    with pytest.raises(ValueError, match="unsupported language"):
+        contract("", "some/path")
+
+
+def test_contract_nonexistent_package_python(tmp_path: Path) -> None:
+    """Dispatching python with a directory that has no __init__.py returns empty list."""
+    empty_dir = tmp_path / "empty"
+    empty_dir.mkdir()
+    parent = str(tmp_path)
+    sys.path.insert(0, parent)
+    try:
+        result = contract("python", "empty")
+        assert result == []
+    finally:
+        sys.path.remove(parent)
+        sys.modules.pop("empty", None)


### PR DESCRIPTION
- Strengthen weak assertions in module-not-found tests to check "package not importable" instead of generic "Error"
- Replace broad ImportError catch in golang dispatcher test with pytest.importorskip to avoid masking real bugs
- Rename misleading test_contract_empty_cell_path_python to test_contract_nonexistent_package_python
- Add missing test for DocumentNotFoundError path in CLI command

feat: add integration tests for contract dispatcher

End-to-end tests covering CLI -> contract_logic -> language function chain for python, golang, multiple cells, and error propagation scenarios.

feat: update contract command to delegate through contract_logic dispatcher

Replace inline dispatch dictionary with delegation through contract() dispatcher imported from goga/contract. Remove direct imports of python_contract/golang_contract and the golang_contract is None check. Add contract and behavioral tests for the command.

feat: implement contract() dispatcher with TDD tests

Replace NotImplementedError stub with working dispatcher that routes calls to python_contract or golang_contract based on lang parameter. Raises ValueError for unsupported languages. All 7 tests pass.

feat: create contract dispatcher stub and wire into facade

Add goga/contract/dispatcher.py with NotImplementedError stub for contract(lang, cell_path). Export from goga/contract/__init__.py.