### PR TITLE
fix: address code review findings

### DIFF
--- a/goga/CODEMANIFEST
+++ b/goga/CODEMANIFEST
@@ -7,6 +7,7 @@ Imports:
       - contract
       - config
       - sync
+      - tool
     From: goga/commands
   - Types:
       - AST
@@ -37,6 +38,7 @@ app():
     - `contract`
     - `config`
     - `sync`
+    - `tool`
 
 ---
 

--- a/goga/cli.py
+++ b/goga/cli.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import click
 
-from .commands import build, config, contract, install, linter, schema, sync
+from .commands import build, config, contract, install, linter, schema, sync, tool
 
 
 @click.group()
@@ -17,3 +17,4 @@ app.add_command(linter)
 app.add_command(schema)
 app.add_command(contract)
 app.add_command(sync)
+app.add_command(tool)

--- a/goga/commands/CODEMANIFEST
+++ b/goga/commands/CODEMANIFEST
@@ -20,6 +20,9 @@ Imports:
   - Types:
       - sync
     From: goga/commands/sync
+  - Types:
+      - tool
+    From: goga/commands/tool
 
 Usages:
   convention: .goga/usages/development/conventions.md
@@ -41,6 +44,7 @@ Annotations: |
 ->contract: {}
 ->config: {}
 ->sync: {}
+->tool: {}
 
 ---
 

--- a/goga/commands/__init__.py
+++ b/goga/commands/__init__.py
@@ -5,5 +5,6 @@ from .install import install
 from .linter import linter
 from .schema import schema
 from .sync import sync
+from .tool import tool
 
-__all__ = ["build", "config", "contract", "install", "linter", "schema", "sync"]
+__all__ = ["build", "config", "contract", "install", "linter", "schema", "sync", "tool"]

--- a/goga/commands/tool/.usages/tool.md
+++ b/goga/commands/tool/.usages/tool.md
@@ -1,0 +1,48 @@
+# Tool command — запуск внешних tool-пакетов
+
+Команда `goga tool` динамически загружает и вызывает внешние tool-пакеты.
+
+## Импорт
+
+```python
+from goga.commands.tool import tool
+```
+
+## Использование в CLI
+
+```bash
+goga tool <name> [args...]
+```
+
+- `<name>` — имя tool-пакета (без префикса `goga_tool_`)
+- `[args...]` — произвольные аргументы, передаваемые в `main(argv)` tool-пакета
+
+## Регистрация в click-группе
+
+```python
+from goga.commands import tool
+
+app.add_command(tool)
+```
+
+## Требования к tool-пакету
+
+Пакет `goga_tool_<name>` должен предоставлять функцию:
+
+```python
+def main(argv: list[str]) -> None:
+    """Entry point для tool-пакета."""
+    ...
+```
+
+## Тестирование
+
+```python
+from click.testing import CliRunner
+from goga.commands.tool import tool
+
+def test_tool_example():
+    runner = CliRunner()
+    result = runner.invoke(tool, ["mytool", "arg1", "--flag", "value"])
+    # Проверка зависит от установленного tool-пакета
+```

--- a/goga/commands/tool/CODEMANIFEST
+++ b/goga/commands/tool/CODEMANIFEST
@@ -1,0 +1,49 @@
+Usages:
+  click: .goga/usages/cooks/click.md
+  convention: .goga/usages/development/conventions.md
+
+Annotations: |
+  Практика `convention` используется для:
+  - работы с кодовой базой
+  - организации REPL цикла разработки
+  - отладки и тестирования
+  - организации тестовой инфраструктуры
+  - понимания общих принципов/правил разработки и тестирования в проекте
+  Для создания команды использовать практику `click`.
+  Динамический импорт через importlib.import_module (stdlib).
+
+---
+
+"tool(name: str, args: list[str])":
+  location: tool.py
+  annotations: |
+    CLI-обёртка команды динамического вызова tool-пакета.
+
+    `name`: имя tool-пакета (без префикса goga_tool_). CLI-позиционный аргумент.
+    `args`: произвольные аргументы, передаваемые в main tool-пакета.
+            Получены через ctx.args (allow_extra_args=True).
+
+    Click-декораторы:
+    - @click.command(context_settings=dict(ignore_unknown_options=True, allow_extra_args=True))
+    - @click.argument('name')
+    - @click.pass_context
+
+    Алгоритм:
+    1. Сформировать имя пакета: f"goga_tool_{name}"
+    2. Импортировать пакет через importlib.import_module
+    3. Получить функцию main из импортированного пакета
+    4. Вызвать main(args)
+
+    Обработка ошибок:
+    - Пакет не найден (ModuleNotFoundError) → понятное сообщение через click.secho
+    - Функция main отсутствует (AttributeError) → понятное сообщение через click.secho
+
+    Использовать практику `click` для создания команды.
+
+---
+
+Author: Goga
+CreatedAt: 25/05/26
+
+Description: |
+  CLI-обёртка команды goga tool — динамический вызов внешних tool-пакетов

--- a/goga/commands/tool/__init__.py
+++ b/goga/commands/tool/__init__.py
@@ -1,0 +1,3 @@
+from .tool import tool as tool
+
+__all__ = ["tool"]

--- a/goga/commands/tool/tool.py
+++ b/goga/commands/tool/tool.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import importlib
+
+import click
+
+
+@click.command(context_settings={"ignore_unknown_options": True, "allow_extra_args": True})
+@click.argument("name")
+@click.pass_context
+def tool(ctx: click.Context, name: str) -> None:
+    """Run an external tool package by name."""
+    package_name = f"goga_tool_{name}"
+    try:
+        module = importlib.import_module(package_name)
+    except ModuleNotFoundError:
+        click.secho(f"Tool package '{package_name}' not found", fg="red", err=True)
+        ctx.exit(1)
+    try:
+        main_fn = module.main
+    except AttributeError:
+        click.secho(f"Tool package '{package_name}' has no 'main' function", fg="red", err=True)
+        ctx.exit(1)
+    main_fn(list(ctx.args))

--- a/tests/commands/tool/test_tool.py
+++ b/tests/commands/tool/test_tool.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import importlib
+import types
+from unittest import mock
+
+import click
+from click.testing import CliRunner
+from goga.commands.tool import tool
+
+
+class TestFacadeAccessible:
+    def test_tool_facade_accessible(self) -> None:
+        """The tool symbol is importable from goga.commands.tool."""
+        assert tool is not None
+
+
+class TestToolIsClickCommand:
+    def test_tool_is_click_command(self) -> None:
+        """The tool object is a click.BaseCommand instance."""
+        assert isinstance(tool, click.Command)
+
+
+class TestToolHasNameArgument:
+    def test_tool_has_name_argument(self) -> None:
+        """The tool command has a 'name' argument."""
+        param_names = [p.name for p in tool.params]
+        assert "name" in param_names
+
+
+class TestToolSuccessfulInvocation:
+    def test_tool_successful_invocation(self) -> None:
+        """Calling tool with a valid package invokes its main with extra args."""
+        captured: list[list[str]] = []
+
+        dummy = types.ModuleType("goga_tool_example")
+        dummy.main = captured.append  # type: ignore[attr-defined]
+
+        runner = CliRunner()
+        with mock.patch.object(importlib, "import_module", return_value=dummy):
+            result = runner.invoke(tool, ["example", "arg1", "--flag", "value"])
+
+        assert result.exit_code == 0
+        assert captured == [["arg1", "--flag", "value"]]
+
+
+class TestToolWithNoArgs:
+    def test_tool_with_no_args(self) -> None:
+        """Calling tool with no extra args invokes main with an empty list."""
+        captured: list[list[str]] = []
+
+        dummy = types.ModuleType("goga_tool_empty")
+        dummy.main = captured.append  # type: ignore[attr-defined]
+
+        runner = CliRunner()
+        with mock.patch.object(importlib, "import_module", return_value=dummy):
+            result = runner.invoke(tool, ["empty"])
+
+        assert result.exit_code == 0
+        assert captured == [[]]
+
+
+class TestToolPackageNotFound:
+    def test_tool_package_not_found(self) -> None:
+        """Missing tool package shows a 'not found' error message."""
+        runner = CliRunner()
+        with mock.patch.object(importlib, "import_module", side_effect=ModuleNotFoundError("goga_tool_nonexistent")):
+            result = runner.invoke(tool, ["nonexistent"])
+
+        assert result.exit_code != 0
+        assert "goga_tool_nonexistent" in result.output
+        assert "not found" in result.output.lower()
+
+
+class TestToolNoMainFunction:
+    def test_tool_no_main_function(self) -> None:
+        """Tool package without a 'main' function shows an error message."""
+        dummy = types.ModuleType("goga_tool_nomain")
+        # Intentionally no 'main' attribute
+
+        runner = CliRunner()
+        with mock.patch.object(importlib, "import_module", return_value=dummy):
+            result = runner.invoke(tool, ["nomain"])
+
+        assert result.exit_code != 0
+        assert "goga_tool_nomain" in result.output
+        assert "main" in result.output
+
+
+class TestToolHelpMessage:
+    def test_tool_help_message(self) -> None:
+        """The --help flag shows usage info with NAME header."""
+        runner = CliRunner()
+        result = runner.invoke(tool, ["--help"])
+
+        assert result.exit_code == 0
+        assert "NAME" in result.output

--- a/tests/commands/tool/test_tool_integration.py
+++ b/tests/commands/tool/test_tool_integration.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import importlib
+import types
+from unittest import mock
+
+from click.testing import CliRunner
+from goga.cli import app
+
+
+class TestToolRegisteredInApp:
+    def test_tool_registered_in_app(self) -> None:
+        """The 'tool' subcommand is listed in app's help output."""
+        runner = CliRunner()
+        result = runner.invoke(app, ["--help"])
+
+        assert result.exit_code == 0
+        assert "tool" in result.output
+
+
+class TestToolInvocationThroughApp:
+    def test_tool_invocation_through_app(self) -> None:
+        """End-to-end: invoking app tool <name> <args> reaches module.main."""
+        captured: list[list[str]] = []
+
+        dummy = types.ModuleType("goga_tool_example")
+
+        def _main(argv: list[str]) -> None:
+            captured.append(argv)
+
+        dummy.main = _main  # type: ignore[attr-defined]
+
+        runner = CliRunner()
+        with mock.patch.object(importlib, "import_module", return_value=dummy):
+            result = runner.invoke(app, ["tool", "example", "arg1"])
+
+        assert result.exit_code == 0
+        assert captured == [["arg1"]]
+
+
+class TestToolNotFoundThroughApp:
+    def test_tool_not_found_through_app(self) -> None:
+        """End-to-end: missing tool package via app shows 'not found' error."""
+        runner = CliRunner()
+        with mock.patch.object(importlib, "import_module", side_effect=ModuleNotFoundError("goga_tool_nonexistent")):
+            result = runner.invoke(app, ["tool", "nonexistent"])
+
+        assert result.exit_code != 0
+        assert "goga_tool_nonexistent" in result.output
+        assert "not found" in result.output.lower()


### PR DESCRIPTION
- Use ctx.exit(1) instead of return on error paths (matches project convention)
- Remove unnecessary from __future__ import annotations from __init__.py
- Replace deprecated click.BaseCommand with click.Command in tests
- Fix pre-existing lint issues (import sorting, unnecessary lambdas)
- Update test assertions to expect non-zero exit code on errors

feat: add integration tests for tool command through app
feat: re-export tool through goga.commands facade and register in CLI
feat: implement tool command for dynamic tool package invocation

Add goga/commands/tool/ module with CLI wrapper that dynamically imports external goga_tool_{name} packages and delegates to their main(argv). Includes contract tests, behavioral tests, and lint compliance.