### PR TITLE
fix: add per-package error isolation in _install_tool_skills

### DIFF
--- a/goga/commands/install/.usages/install.md
+++ b/goga/commands/install/.usages/install.md
@@ -15,6 +15,7 @@ goga install [--agent <name>]
 | Опция | Тип | Дефолт | Описание |
 |-------|-----|--------|----------|
 | `--agent` | str | из конфига | Целевой AI-агент |
+| `--force-overwrite` | flag | False | Перезаписывать существующие скиллы при установке из пакетов инструментов |
 
 ## Код возврата
 
@@ -26,4 +27,6 @@ goga install [--agent <name>]
 ```bash
 goga install
 goga install --agent claude
+goga install --force-overwrite
+goga install --agent claude --force-overwrite
 ```

--- a/goga/commands/install/CODEMANIFEST
+++ b/goga/commands/install/CODEMANIFEST
@@ -25,19 +25,21 @@ Annotations: |
 
 ---
 
-"install(agent: str | None = None)":
+"install(agent: str | None = None, force_overwrite: bool = False)":
   location: install.py
   annotations: |
     CLI-обёртка команды установки. Делегирует бизнес-логику `install_logic`.
 
     `agent`: целевой AI-агент
+    `force_overwrite`: разрешить перезапись существующих скиллов
 
     CLI-опции:
     - --agent: целевой AI-агент
+    - --force-overwrite: перезаписывать существующие скиллы при установке из инструментов
 
     Алгоритм:
     1. Загрузить конфигурацию через `load_config` (практика `configuration`) → получить `Config`
-    2. Вызвать `install_logic`(`agent`, `Config`)
+    2. Вызвать `install_logic`(`agent`, `Config`, `force_overwrite`)
     3. Вернуть exit_code
 
 ---

--- a/goga/commands/install/install.py
+++ b/goga/commands/install/install.py
@@ -9,13 +9,14 @@ from goga.install import install as install_logic
 
 @click.command()
 @click.option("--agent", default=None, help="Target AI agent")
+@click.option("--force-overwrite", is_flag=True, default=False, help="Overwrite existing tool skills")
 @click.pass_context
-def install(ctx: click.Context, agent: str | None) -> None:
+def install(ctx: click.Context, agent: str | None, force_overwrite: bool) -> None:
     """Install goga skills and commands into the target AI agent configuration."""
     try:
         config = load_config()
     except (FileNotFoundError, KeyError, ValueError, yaml.YAMLError) as exc:
         raise click.ClickException(str(exc)) from exc
 
-    exit_code = install_logic(agent, config)
+    exit_code = install_logic(agent, config, force_overwrite=force_overwrite)
     ctx.exit(exit_code)

--- a/goga/install/.usages/install-usage.md
+++ b/goga/install/.usages/install-usage.md
@@ -19,12 +19,16 @@ exit_code = install(agent=None, config=config)
 
 # Установка с явным agent
 exit_code = install(agent="claude", config=config)
+
+# Установка с перезаписью tool skills
+exit_code = install(agent="claude", config=config, force_overwrite=True)
 ```
 
 ## Параметры
 
 - `agent` — целевой AI-агент ("claude"). Если None — из config
 - `config` — объект Config, загруженный через `load_config`
+- `force_overwrite` — разрешить перезапись существующих скиллов из пакетов инструментов. По умолчанию False
 
 ## Возвращаемое значение
 
@@ -37,6 +41,10 @@ exit_code = install(agent="claude", config=config)
 - Копирует goga/agent/commands/* → <target>/commands/goga/
 - Копирует goga/agent/skills/* → <target>/skills/
 - Скачивает dsl.md из GitHub и записывает в <target>/skills/goga-cell/dsl.md
+- Обнаруживает Python-пакеты с префиксом `goga_tool_*` через importlib.metadata
+- Копирует скиллы из обнаруженных пакетов в <target>/skills/ с префиксом `goga-tool-`
+- При `force_overwrite=False` — пропускает существующие скиллы с предупреждением
+- При `force_overwrite=True` — перезаписывает существующие скиллы
 
 ## Целевые каталоги
 

--- a/goga/install/CODEMANIFEST
+++ b/goga/install/CODEMANIFEST
@@ -14,13 +14,15 @@ Annotations: |
 
 ---
 
-"install(agent: str | None, config: Config) -> exit_code:int":
+"install(agent: str | None, config: Config, force_overwrite: bool = False) -> exit_code:int":
   location: install.py
   annotations: |
-    Установка скиллов и команд goga для выбранного AI-агента.
+    Установка скиллов и команд goga для выбранного AI-агента,
+    включая скиллы из установленных пакетов инструментов.
 
     `agent`: целевой AI-агент. Если None — берётся из config
     `config`: загруженная конфигурация проекта
+    `force_overwrite`: разрешить перезапись существующих скиллов. По умолчанию False
     `exit_code`: код возврата (0 успех, 1 ошибка)
 
     Алгоритм:
@@ -40,15 +42,34 @@ Annotations: |
        - HTTP GET через urllib.request
        - Записать в <target>/skills/goga-cell/dsl.md
        - При ошибке сети — exit 1
-    6. Вывести список установленных скиллов и команд
+    6. Установить скиллы из пакетов инструментов:
+       a. Обнаружить все установленные Python-пакеты с префиксом goga_tool_
+          через importlib.metadata.packages_distributions()
+       b. Для каждого найденного пакета goga_tool_<tool_name>:
+          - Получить путь к пакету: найти файл __init__.py внутри пакета,
+            определить родительский каталог как корень пакета
+          - Валидация: проверить наличие <package>/skills/<tool_name>/SKILL.md
+            - Если не найден — вывести предупреждение в stderr
+              и пропустить весь пакет
+          - Скопировать все скиллы из <package>/skills/* в <target>/skills/
+            с добавлением префикса goga-tool- к имени каждого скилла:
+            - <package>/skills/debug/ → <target>/skills/goga-tool-debug/
+            - <package>/skills/analyze/ → <target>/skills/goga-tool-analyze/
+          - Если целевой скилл уже существует и force_overwrite=False —
+            пропустить с предупреждением в stderr
+          - Если force_overwrite=True — перезаписать (shutil.rmtree + shutil.copytree)
+    7. Вывести список установленных скиллов и команд
 
     Требования:
-    - Полное пересоздание goga-папок (удаление + копирование)
+    - Полное пересоздание goga-папок при шаге 3 (удаление + копирование)
     - Существующий контент других расширений не затрагивать
     - CLAUDE.md, settings.json, README.md целевого каталога не затрагивать
     - dsl.md скачивается из внешнего репозитория при каждой установке
     - Использовать urllib.request (без внешних зависимостей)
-    - При ошибке скачивания — прервать с кодом 1
+    - Использовать importlib.metadata из стандартной библиотеки
+    - При ошибке скачивания dsl.md — прервать с кодом 1
+    - Имя скилла из инструмента формируется как goga-tool-<skill_dir_name>
+    - Пакет инструмента без entry-point скилла пропускается целиком
 
 ---
 
@@ -56,4 +77,5 @@ Author: Mikhail Trifonov
 CreatedAt: 15/05/26
 
 Description: |
-  Манифест описывает логику установки скиллов и команд goga
+  Манифест описывает логику установки скиллов и команд goga,
+  включая установку скиллов из пакетов инструментов goga_tool_*

--- a/goga/install/install.py
+++ b/goga/install/install.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import importlib.metadata
+import importlib.util
 import shutil
 import sys
 import urllib.error
@@ -75,7 +77,49 @@ def _print_summary(commands: list[str], skills: list[str], target: Path) -> None
     print(f"Installed {len(skills)} skills: {', '.join(skills)}", file=sys.stderr)
 
 
-def install(agent: str | None = None, config: Config | None = None) -> int:
+def _install_tool_skills(target: Path, force_overwrite: bool) -> list[str]:
+    pkg_map = importlib.metadata.packages_distributions()
+    tool_skills: list[str] = []
+    for top_level_name in sorted(pkg_map):
+        if not top_level_name.startswith("goga_tool_"):
+            continue
+        try:
+            spec = importlib.util.find_spec(top_level_name)
+        except (ModuleNotFoundError, ValueError):
+            continue
+        if spec is None or spec.origin is None:
+            continue
+        package_path = Path(spec.origin).parent
+        tool_name = top_level_name.removeprefix("goga_tool_")
+        if not (package_path / "skills" / tool_name / "SKILL.md").is_file():
+            print(
+                f"Warning: package {top_level_name} missing skills/{tool_name}/SKILL.md, skipping",
+                file=sys.stderr,
+            )
+            continue
+        try:
+            skills_dir = package_path / "skills"
+            for skill_entry in skills_dir.iterdir():
+                if not skill_entry.is_dir():
+                    continue
+                dest = target / "skills" / f"goga-tool-{skill_entry.name}"
+                if dest.exists():
+                    if not force_overwrite:
+                        print(
+                            f"Warning: skill {dest.name} already exists, skipping",
+                            file=sys.stderr,
+                        )
+                        continue
+                    shutil.rmtree(dest)
+                shutil.copytree(skill_entry, dest)
+                if dest.name not in tool_skills:
+                    tool_skills.append(dest.name)
+        except (OSError, shutil.Error) as e:
+            print(f"Warning: failed to install skills from {top_level_name}: {e}", file=sys.stderr)
+    return tool_skills
+
+
+def install(agent: str | None = None, config: Config | None = None, force_overwrite: bool = False) -> int:
     if config is None:
         print("Error: config is required", file=sys.stderr)
         return 1
@@ -99,8 +143,10 @@ def install(agent: str | None = None, config: Config | None = None) -> int:
         commands = _install_commands(source, target)
         skills = _install_skills(source, target)
         _download_dsl_spec(target)
+        tool_skills = _install_tool_skills(target, force_overwrite)
+        skills.extend(tool_skills)
         _print_summary(commands, skills, target)
-    except OSError as e:
+    except (OSError, shutil.Error) as e:
         print(f"Error: {e}", file=sys.stderr)
         return 1
 

--- a/tests/commands/test_install.py
+++ b/tests/commands/test_install.py
@@ -56,6 +56,23 @@ class TestFacadeAvailability:
         assert load_config is not None
 
 
+class TestForceOverwriteContract:
+    """Contract tests -- verify --force-overwrite option on CLI install."""
+
+    def test_force_overwrite_param_exists(self) -> None:
+        params = {p.name for p in install.params}
+        assert "force_overwrite" in params
+
+    def test_force_overwrite_is_flag(self) -> None:
+        param = next(p for p in install.params if p.name == "force_overwrite")
+        assert isinstance(param, click.Option)
+        assert param.is_flag
+
+    def test_force_overwrite_default_is_false(self) -> None:
+        param = next(p for p in install.params if p.name == "force_overwrite")
+        assert param.default is False
+
+
 class TestCleanupGogaSkillsContract:
     """Contract tests for _cleanup_goga_skills function."""
 
@@ -579,3 +596,37 @@ class TestDownloadDslSpecLogic:
             result = CliRunner().invoke(app, ["install"])
         assert result.exit_code == 1
         assert "Error:" in result.output
+
+
+class TestForceOverwriteLogic:
+    """Logical tests -- verify --force-overwrite CLI behavior."""
+
+    def test_install_cli_force_overwrite_flag(self, tmp_path: Path) -> None:
+        with (
+            mock.patch("pathlib.Path.home", return_value=tmp_path),
+            mock.patch("urllib.request.urlopen", return_value=_mock_urlopen_response()),
+        ):
+            result = CliRunner().invoke(app, ["install", "--force-overwrite"])
+        assert result.exit_code == 0
+
+    def test_install_cli_default_no_force(self, tmp_path: Path) -> None:
+        with (
+            mock.patch("pathlib.Path.home", return_value=tmp_path),
+            mock.patch("urllib.request.urlopen", return_value=_mock_urlopen_response()),
+            mock.patch("goga.commands.install.install.install_logic") as mock_logic,
+        ):
+            mock_logic.return_value = 0
+            CliRunner().invoke(app, ["install"])
+        mock_logic.assert_called_once()
+        assert mock_logic.call_args.kwargs.get("force_overwrite") is False
+
+    def test_install_cli_passes_force_overwrite_true(self, tmp_path: Path) -> None:
+        with (
+            mock.patch("pathlib.Path.home", return_value=tmp_path),
+            mock.patch("urllib.request.urlopen", return_value=_mock_urlopen_response()),
+            mock.patch("goga.commands.install.install.install_logic") as mock_logic,
+        ):
+            mock_logic.return_value = 0
+            CliRunner().invoke(app, ["install", "--force-overwrite"])
+        mock_logic.assert_called_once()
+        assert mock_logic.call_args.kwargs.get("force_overwrite") is True

--- a/tests/commands/test_install.py
+++ b/tests/commands/test_install.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import importlib
 import inspect
 import sys
 import urllib.error
@@ -14,6 +15,7 @@ from goga.config import load_config
 from goga.install.install import _cleanup_goga_skills
 
 _install_module = sys.modules["goga.install.install"]
+_cmd_install_module = importlib.import_module("goga.commands.install.install")
 _AGENT_SOURCE_DIR = Path(__file__).parent.parent.parent / "goga" / "agent"
 
 
@@ -613,7 +615,7 @@ class TestForceOverwriteLogic:
         with (
             mock.patch("pathlib.Path.home", return_value=tmp_path),
             mock.patch("urllib.request.urlopen", return_value=_mock_urlopen_response()),
-            mock.patch("goga.commands.install.install.install_logic") as mock_logic,
+            mock.patch.object(_cmd_install_module, "install_logic") as mock_logic,
         ):
             mock_logic.return_value = 0
             CliRunner().invoke(app, ["install"])
@@ -624,7 +626,7 @@ class TestForceOverwriteLogic:
         with (
             mock.patch("pathlib.Path.home", return_value=tmp_path),
             mock.patch("urllib.request.urlopen", return_value=_mock_urlopen_response()),
-            mock.patch("goga.commands.install.install.install_logic") as mock_logic,
+            mock.patch.object(_cmd_install_module, "install_logic") as mock_logic,
         ):
             mock_logic.return_value = 0
             CliRunner().invoke(app, ["install", "--force-overwrite"])

--- a/tests/install/test_contract.py
+++ b/tests/install/test_contract.py
@@ -13,7 +13,7 @@ class TestInstallContract:
     def test_install_has_correct_signature(self) -> None:
         sig = inspect.signature(install)
         params = list(sig.parameters.keys())
-        assert params == ["agent", "config"]
+        assert params == ["agent", "config", "force_overwrite"]
 
     def test_install_agent_param_is_optional_str(self) -> None:
         hints = typing.get_type_hints(install)

--- a/tests/install/test_install.py
+++ b/tests/install/test_install.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib
+import inspect
 import urllib.error
 from pathlib import Path
 from unittest import mock
@@ -13,6 +14,7 @@ from goga.install.install import (
     _get_source_dir,
     _install_commands,
     _install_skills,
+    _install_tool_skills,
     _print_summary,
     _resolve_target_dir,
     install,
@@ -383,3 +385,455 @@ class TestInstall:
             result = install(agent="claude", config=config)
 
         assert result == 0
+
+
+# --- Contract tests for force_overwrite parameter ---
+
+
+class TestInstallSignatureContract:
+    def test_install_has_three_parameters(self) -> None:
+        sig = inspect.signature(install)
+        params = list(sig.parameters.keys())
+        assert params == ["agent", "config", "force_overwrite"]
+
+    def test_force_overwrite_default_is_false(self) -> None:
+        sig = inspect.signature(install)
+        param = sig.parameters["force_overwrite"]
+        assert param.default is False
+
+    def test_force_overwrite_is_bool_type(self) -> None:
+        hints = inspect.get_annotations(install, eval_str=True)
+        assert hints["force_overwrite"] is bool
+
+    def test_install_accepts_force_overwrite_false(self, tmp_path: Path) -> None:
+        config = _make_config()
+        _create_agent_resources(tmp_path)
+        mock_source = tmp_path / "goga" / "agent"
+        mock_home = tmp_path / "home"
+        mock_home.mkdir()
+
+        with (
+            mock.patch.object(_install_mod, "_get_source_dir", return_value=mock_source),
+            mock.patch.object(_install_mod.Path, "home", return_value=mock_home),
+            mock.patch.object(_install_mod, "_download_dsl_spec"),
+        ):
+            result = install(agent="claude", config=config, force_overwrite=False)
+
+        assert result == 0
+
+    def test_install_accepts_force_overwrite_true(self, tmp_path: Path) -> None:
+        config = _make_config()
+        _create_agent_resources(tmp_path)
+        mock_source = tmp_path / "goga" / "agent"
+        mock_home = tmp_path / "home"
+        mock_home.mkdir()
+
+        with (
+            mock.patch.object(_install_mod, "_get_source_dir", return_value=mock_source),
+            mock.patch.object(_install_mod.Path, "home", return_value=mock_home),
+            mock.patch.object(_install_mod, "_download_dsl_spec"),
+        ):
+            result = install(agent="claude", config=config, force_overwrite=True)
+
+        assert result == 0
+
+
+# --- Contract tests for _install_tool_skills ---
+
+
+class TestInstallToolSkillsContract:
+    def test_install_tool_skills_exists(self) -> None:
+        assert hasattr(_install_mod, "_install_tool_skills")
+
+    def test_install_tool_skills_is_callable(self) -> None:
+        assert callable(_install_mod._install_tool_skills)
+
+    def test_install_tool_skills_has_two_params(self) -> None:
+        sig = inspect.signature(_install_tool_skills)
+        params = list(sig.parameters.keys())
+        assert params == ["target", "force_overwrite"]
+
+    def test_install_tool_skills_param_types(self) -> None:
+        hints = inspect.get_annotations(_install_tool_skills, eval_str=True)
+        assert hints["target"] is Path
+        assert hints["force_overwrite"] is bool
+
+    def test_install_tool_skills_return_type(self) -> None:
+        hints = inspect.get_annotations(_install_tool_skills, eval_str=True)
+        assert hints["return"] == list[str]
+
+
+# --- Helpers for _install_tool_skills tests ---
+
+
+def _create_tool_package(
+    parent: Path,
+    pkg_name: str,
+    extra_skills: list[str] | None = None,
+    has_entry_point: bool = True,
+) -> Path:
+    pkg_dir = parent / pkg_name
+    pkg_dir.mkdir(parents=True)
+    (pkg_dir / "__init__.py").write_text("")
+
+    tool_name = pkg_name.removeprefix("goga_tool_")
+    skills_dir = pkg_dir / "skills"
+    skills_dir.mkdir()
+
+    if has_entry_point:
+        entry = skills_dir / tool_name
+        entry.mkdir()
+        (entry / "SKILL.md").write_text(f"# {tool_name}")
+
+    for name in extra_skills or []:
+        sdir = skills_dir / name
+        sdir.mkdir()
+        (sdir / "SKILL.md").write_text(f"# {name}")
+
+    return pkg_dir
+
+
+def _make_find_spec_side_effect(spec_map: dict[str, Path]):
+    def find_spec(name: str):
+        if name in spec_map:
+            spec = mock.MagicMock()
+            spec.origin = str(spec_map[name] / "__init__.py")
+            return spec
+        return None
+
+    return find_spec
+
+
+# --- Logical tests for _install_tool_skills ---
+
+
+class TestInstallToolSkills:
+    def test_discovers_and_installs_tool_skill(self, tmp_path: Path) -> None:
+        pkg_dir = _create_tool_package(tmp_path, "goga_tool_debug")
+        target = tmp_path / "target"
+        (target / "skills").mkdir(parents=True)
+
+        with (
+            mock.patch.object(
+                _install_mod.importlib.metadata,
+                "packages_distributions",
+                return_value={"goga_tool_debug": ["goga-tool-debug"]},
+            ),
+            mock.patch.object(
+                _install_mod.importlib.util,
+                "find_spec",
+                side_effect=_make_find_spec_side_effect({"goga_tool_debug": pkg_dir}),
+            ),
+        ):
+            result = _install_tool_skills(target, False)
+
+        assert "goga-tool-debug" in result
+        assert (target / "skills" / "goga-tool-debug" / "SKILL.md").exists()
+
+    def test_installs_multiple_tool_packages(self, tmp_path: Path) -> None:
+        pkg1 = _create_tool_package(tmp_path, "goga_tool_debug")
+        pkg2 = _create_tool_package(tmp_path, "goga_tool_analyze")
+        target = tmp_path / "target"
+        (target / "skills").mkdir(parents=True)
+
+        with (
+            mock.patch.object(
+                _install_mod.importlib.metadata,
+                "packages_distributions",
+                return_value={
+                    "goga_tool_debug": ["goga-tool-debug"],
+                    "goga_tool_analyze": ["goga-tool-analyze"],
+                },
+            ),
+            mock.patch.object(
+                _install_mod.importlib.util,
+                "find_spec",
+                side_effect=_make_find_spec_side_effect(
+                    {"goga_tool_debug": pkg1, "goga_tool_analyze": pkg2}
+                ),
+            ),
+        ):
+            result = _install_tool_skills(target, False)
+
+        assert "goga-tool-debug" in result
+        assert "goga-tool-analyze" in result
+
+    def test_force_overwrite_replaces_existing(self, tmp_path: Path) -> None:
+        pkg_dir = _create_tool_package(tmp_path, "goga_tool_debug")
+        target = tmp_path / "target"
+        existing = target / "skills" / "goga-tool-debug"
+        existing.mkdir(parents=True)
+        (existing / "old.txt").write_text("old")
+
+        with (
+            mock.patch.object(
+                _install_mod.importlib.metadata,
+                "packages_distributions",
+                return_value={"goga_tool_debug": ["goga-tool-debug"]},
+            ),
+            mock.patch.object(
+                _install_mod.importlib.util,
+                "find_spec",
+                side_effect=_make_find_spec_side_effect({"goga_tool_debug": pkg_dir}),
+            ),
+        ):
+            result = _install_tool_skills(target, True)
+
+        assert "goga-tool-debug" in result
+        assert not (existing / "old.txt").exists()
+        assert (existing / "SKILL.md").exists()
+
+    def test_multiple_skills_in_one_package(self, tmp_path: Path) -> None:
+        pkg_dir = tmp_path / "goga_tool_debug"
+        pkg_dir.mkdir(parents=True)
+        (pkg_dir / "__init__.py").write_text("")
+        skills_dir = pkg_dir / "skills"
+        skills_dir.mkdir()
+
+        (skills_dir / "debug").mkdir()
+        (skills_dir / "debug" / "SKILL.md").write_text("# debug")
+        (skills_dir / "analyze").mkdir()
+        (skills_dir / "analyze" / "SKILL.md").write_text("# analyze")
+        (skills_dir / "helpers.md").write_text("helpers")
+
+        target = tmp_path / "target"
+        (target / "skills").mkdir(parents=True)
+
+        with (
+            mock.patch.object(
+                _install_mod.importlib.metadata,
+                "packages_distributions",
+                return_value={"goga_tool_debug": ["goga-tool-debug"]},
+            ),
+            mock.patch.object(
+                _install_mod.importlib.util,
+                "find_spec",
+                side_effect=_make_find_spec_side_effect({"goga_tool_debug": pkg_dir}),
+            ),
+        ):
+            result = _install_tool_skills(target, False)
+
+        assert sorted(result) == ["goga-tool-analyze", "goga-tool-debug"]
+        assert (target / "skills" / "goga-tool-debug" / "SKILL.md").exists()
+        assert (target / "skills" / "goga-tool-analyze" / "SKILL.md").exists()
+        assert not (target / "skills" / "helpers.md").exists()
+
+    def test_package_no_entry_point(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        pkg_dir = _create_tool_package(
+            tmp_path, "goga_tool_debug", has_entry_point=False
+        )
+        target = tmp_path / "target"
+        (target / "skills").mkdir(parents=True)
+
+        with (
+            mock.patch.object(
+                _install_mod.importlib.metadata,
+                "packages_distributions",
+                return_value={"goga_tool_debug": ["goga-tool-debug"]},
+            ),
+            mock.patch.object(
+                _install_mod.importlib.util,
+                "find_spec",
+                side_effect=_make_find_spec_side_effect({"goga_tool_debug": pkg_dir}),
+            ),
+        ):
+            result = _install_tool_skills(target, False)
+
+        assert result == []
+        captured = capsys.readouterr()
+        assert "missing skills/debug/SKILL.md" in captured.err
+
+    def test_skill_exists_no_overwrite(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        pkg_dir = _create_tool_package(tmp_path, "goga_tool_debug")
+        target = tmp_path / "target"
+        existing = target / "skills" / "goga-tool-debug"
+        existing.mkdir(parents=True)
+        (existing / "old.txt").write_text("old")
+
+        with (
+            mock.patch.object(
+                _install_mod.importlib.metadata,
+                "packages_distributions",
+                return_value={"goga_tool_debug": ["goga-tool-debug"]},
+            ),
+            mock.patch.object(
+                _install_mod.importlib.util,
+                "find_spec",
+                side_effect=_make_find_spec_side_effect({"goga_tool_debug": pkg_dir}),
+            ),
+        ):
+            result = _install_tool_skills(target, False)
+
+        assert result == []
+        assert (existing / "old.txt").exists()
+        captured = capsys.readouterr()
+        assert "already exists" in captured.err
+
+    def test_no_tool_packages(self, tmp_path: Path) -> None:
+        target = tmp_path / "target"
+        (target / "skills").mkdir(parents=True)
+
+        with mock.patch.object(
+            _install_mod.importlib.metadata,
+            "packages_distributions",
+            return_value={"requests": ["requests"]},
+        ):
+            result = _install_tool_skills(target, False)
+
+        assert result == []
+
+    def test_find_spec_returns_none(self, tmp_path: Path) -> None:
+        target = tmp_path / "target"
+        (target / "skills").mkdir(parents=True)
+
+        with (
+            mock.patch.object(
+                _install_mod.importlib.metadata,
+                "packages_distributions",
+                return_value={"goga_tool_debug": ["goga-tool-debug"]},
+            ),
+            mock.patch.object(
+                _install_mod.importlib.util, "find_spec", return_value=None
+            ),
+        ):
+            result = _install_tool_skills(target, False)
+
+        assert result == []
+
+    def test_preserves_core_skills(self, tmp_path: Path) -> None:
+        pkg_dir = _create_tool_package(tmp_path, "goga_tool_debug")
+        target = tmp_path / "target"
+        (target / "skills" / "goga-cell").mkdir(parents=True)
+        (target / "skills" / "goga-cell" / "SKILL.md").write_text("# cell")
+
+        with (
+            mock.patch.object(
+                _install_mod.importlib.metadata,
+                "packages_distributions",
+                return_value={"goga_tool_debug": ["goga-tool-debug"]},
+            ),
+            mock.patch.object(
+                _install_mod.importlib.util,
+                "find_spec",
+                side_effect=_make_find_spec_side_effect({"goga_tool_debug": pkg_dir}),
+            ),
+        ):
+            result = _install_tool_skills(target, False)
+
+        assert "goga-tool-debug" in result
+        assert (target / "skills" / "goga-cell" / "SKILL.md").exists()
+
+    def test_cleanup_removes_old_tool_skills(self, tmp_path: Path) -> None:
+        config = _make_config()
+        _create_agent_resources(tmp_path)
+        mock_source = tmp_path / "goga" / "agent"
+        mock_home = tmp_path / "home"
+        (mock_home / ".claude" / "skills" / "goga-tool-obsolete").mkdir(parents=True)
+        (mock_home / ".claude" / "skills" / "goga-tool-obsolete" / "SKILL.md").write_text("# old")
+
+        pkg_dir = _create_tool_package(tmp_path / "pkgs", "goga_tool_debug")
+
+        with (
+            mock.patch.object(_install_mod, "_get_source_dir", return_value=mock_source),
+            mock.patch.object(_install_mod.Path, "home", return_value=mock_home),
+            mock.patch.object(_install_mod, "_download_dsl_spec"),
+            mock.patch.object(
+                _install_mod.importlib.metadata,
+                "packages_distributions",
+                return_value={"goga_tool_debug": ["goga-tool-debug"]},
+            ),
+            mock.patch.object(
+                _install_mod.importlib.util,
+                "find_spec",
+                side_effect=_make_find_spec_side_effect({"goga_tool_debug": pkg_dir}),
+            ),
+        ):
+            result = install(agent="claude", config=config)
+
+        assert result == 0
+        assert not (mock_home / ".claude" / "skills" / "goga-tool-obsolete").exists()
+        assert (mock_home / ".claude" / "skills" / "goga-tool-debug").is_dir()
+
+    def test_two_packages_same_skill_name(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        pkg1 = tmp_path / "goga_tool_debug"
+        pkg1.mkdir(parents=True)
+        (pkg1 / "__init__.py").write_text("")
+        (pkg1 / "skills" / "debug").mkdir(parents=True)
+        (pkg1 / "skills" / "debug" / "SKILL.md").write_text("# debug v1")
+
+        pkg2 = tmp_path / "goga_tool_analyze"
+        pkg2.mkdir(parents=True)
+        (pkg2 / "__init__.py").write_text("")
+        (pkg2 / "skills" / "analyze").mkdir(parents=True)
+        (pkg2 / "skills" / "analyze" / "SKILL.md").write_text("# analyze v1")
+        (pkg2 / "skills" / "debug").mkdir(parents=True)
+        (pkg2 / "skills" / "debug" / "SKILL.md").write_text("# debug v2")
+
+        target = tmp_path / "target"
+        (target / "skills").mkdir(parents=True)
+
+        with (
+            mock.patch.object(
+                _install_mod.importlib.metadata,
+                "packages_distributions",
+                return_value={
+                    "goga_tool_debug": ["goga-tool-debug"],
+                    "goga_tool_analyze": ["goga-tool-analyze"],
+                },
+            ),
+            mock.patch.object(
+                _install_mod.importlib.util,
+                "find_spec",
+                side_effect=_make_find_spec_side_effect(
+                    {"goga_tool_debug": pkg1, "goga_tool_analyze": pkg2}
+                ),
+            ),
+        ):
+            result = _install_tool_skills(target, False)
+
+        assert "goga-tool-debug" in result
+        assert "goga-tool-analyze" in result
+        content = (target / "skills" / "goga-tool-debug" / "SKILL.md").read_text()
+        assert "v2" in content
+        captured = capsys.readouterr()
+        assert "already exists" in captured.err
+
+    def test_empty_packages_distributions(self, tmp_path: Path) -> None:
+        target = tmp_path / "target"
+        (target / "skills").mkdir(parents=True)
+
+        with mock.patch.object(
+            _install_mod.importlib.metadata,
+            "packages_distributions",
+            return_value={},
+        ):
+            result = _install_tool_skills(target, False)
+
+        assert result == []
+
+    def test_find_spec_origin_is_none(self, tmp_path: Path) -> None:
+        target = tmp_path / "target"
+        (target / "skills").mkdir(parents=True)
+
+        spec = mock.MagicMock()
+        spec.origin = None
+
+        with (
+            mock.patch.object(
+                _install_mod.importlib.metadata,
+                "packages_distributions",
+                return_value={"goga_tool_debug": ["goga-tool-debug"]},
+            ),
+            mock.patch.object(
+                _install_mod.importlib.util, "find_spec", return_value=spec
+            ),
+        ):
+            result = _install_tool_skills(target, False)
+
+        assert result == []

--- a/tests/install/test_integration_tool_skills.py
+++ b/tests/install/test_integration_tool_skills.py
@@ -1,0 +1,361 @@
+"""Integration tests for install-tool-packages: end-to-end scenarios covering
+core + tool skills coexistence, cleanup, name conflicts, and CLI behavior."""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+from unittest import mock
+
+import pytest
+from click.testing import CliRunner
+from goga.cli import app
+from goga.config import BuildConfig, Config, TaskExecutor
+from goga.install.install import _install_tool_skills, install
+
+_install_mod = importlib.import_module("goga.install.install")
+
+
+def _make_config(agent: str = "claude") -> Config:
+    task_executor = TaskExecutor(agent=agent, env={})
+    build = BuildConfig(task_executor=task_executor)
+    return Config(lang="python", build=build)
+
+
+def _create_agent_resources(target: Path) -> Path:
+    source = target / "goga" / "agent"
+    (source / "commands").mkdir(parents=True)
+    (source / "commands" / "build.md").write_text("# build command")
+    (source / "commands" / "install.md").write_text("# install command")
+    (source / "skills" / "goga-cell").mkdir(parents=True)
+    (source / "skills" / "goga-cell" / "SKILL.md").write_text("# cell skill")
+    (source / "skills" / "other-skill").mkdir(parents=True)
+    (source / "skills" / "other-skill" / "SKILL.md").write_text("# other")
+    return source
+
+
+def _create_tool_package(
+    parent: Path,
+    pkg_name: str,
+    extra_skills: list[str] | None = None,
+    has_entry_point: bool = True,
+) -> Path:
+    pkg_dir = parent / pkg_name
+    pkg_dir.mkdir(parents=True)
+    (pkg_dir / "__init__.py").write_text("")
+    tool_name = pkg_name.removeprefix("goga_tool_")
+    skills_dir = pkg_dir / "skills"
+    skills_dir.mkdir()
+    if has_entry_point:
+        entry = skills_dir / tool_name
+        entry.mkdir()
+        (entry / "SKILL.md").write_text(f"# {tool_name}")
+    for name in extra_skills or []:
+        sdir = skills_dir / name
+        sdir.mkdir()
+        (sdir / "SKILL.md").write_text(f"# {name}")
+    return pkg_dir
+
+
+def _make_find_spec_side_effect(spec_map: dict[str, Path]):
+    def find_spec(name: str):
+        if name in spec_map:
+            spec = mock.MagicMock()
+            spec.origin = str(spec_map[name] / "__init__.py")
+            return spec
+        return None
+
+    return find_spec
+
+
+def _mock_urlopen_response(content: bytes = b"dsl content") -> mock.MagicMock:
+    mock_response = mock.MagicMock()
+    mock_response.read.return_value = content
+    mock_response.__enter__ = mock.MagicMock(return_value=mock_response)
+    mock_response.__exit__ = mock.MagicMock(return_value=False)
+    return mock_response
+
+
+class TestFullInstallCycleWithToolPackages:
+    """Test: full install cycle — core skills + tool skills installed correctly,
+    _print_summary outputs total count."""
+
+    def test_core_and_tool_skills_both_installed(self, tmp_path: Path) -> None:
+        config = _make_config()
+        _create_agent_resources(tmp_path)
+        mock_source = tmp_path / "goga" / "agent"
+        mock_home = tmp_path / "home"
+        mock_home.mkdir()
+
+        pkg_dir = _create_tool_package(tmp_path / "pkgs", "goga_tool_debug")
+
+        with (
+            mock.patch.object(_install_mod, "_get_source_dir", return_value=mock_source),
+            mock.patch.object(_install_mod.Path, "home", return_value=mock_home),
+            mock.patch.object(_install_mod, "_download_dsl_spec"),
+            mock.patch.object(
+                _install_mod.importlib.metadata,
+                "packages_distributions",
+                return_value={"goga_tool_debug": ["goga-tool-debug"]},
+            ),
+            mock.patch.object(
+                _install_mod.importlib.util,
+                "find_spec",
+                side_effect=_make_find_spec_side_effect({"goga_tool_debug": pkg_dir}),
+            ),
+        ):
+            result = install(agent="claude", config=config)
+
+        assert result == 0
+        target = mock_home / ".claude"
+        # Core skills installed
+        assert (target / "skills" / "goga-cell" / "SKILL.md").is_file()
+        assert (target / "skills" / "other-skill" / "SKILL.md").is_file()
+        # Tool skills installed
+        assert (target / "skills" / "goga-tool-debug" / "SKILL.md").is_file()
+
+    def test_print_summary_includes_tool_skills_count(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        config = _make_config()
+        _create_agent_resources(tmp_path)
+        mock_source = tmp_path / "goga" / "agent"
+        mock_home = tmp_path / "home"
+        mock_home.mkdir()
+
+        pkg_dir = _create_tool_package(tmp_path / "pkgs", "goga_tool_debug")
+
+        with (
+            mock.patch.object(_install_mod, "_get_source_dir", return_value=mock_source),
+            mock.patch.object(_install_mod.Path, "home", return_value=mock_home),
+            mock.patch.object(_install_mod, "_download_dsl_spec"),
+            mock.patch.object(
+                _install_mod.importlib.metadata,
+                "packages_distributions",
+                return_value={"goga_tool_debug": ["goga-tool-debug"]},
+            ),
+            mock.patch.object(
+                _install_mod.importlib.util,
+                "find_spec",
+                side_effect=_make_find_spec_side_effect({"goga_tool_debug": pkg_dir}),
+            ),
+        ):
+            result = install(agent="claude", config=config)
+
+        assert result == 0
+        captured = capsys.readouterr()
+        # 2 core skills (goga-cell, other-skill) + 1 tool skill = 3 total
+        assert "Installed 3 skills" in captured.err
+        assert "goga-cell" in captured.err
+        assert "goga-tool-debug" in captured.err
+
+
+class TestCleanupObsoleteToolSkills:
+    """Test: cleanup removes obsolete goga-tool-* during reinstall,
+    but preserves goga-tool-* from current packages."""
+
+    def test_cleanup_removes_obsolete_but_keeps_current(self, tmp_path: Path) -> None:
+        config = _make_config()
+        _create_agent_resources(tmp_path)
+        mock_source = tmp_path / "goga" / "agent"
+        mock_home = tmp_path / "home"
+        mock_home.mkdir()
+
+        # Pre-existing obsolete tool skill
+        (mock_home / ".claude" / "skills" / "goga-tool-obsolete").mkdir(parents=True)
+        (mock_home / ".claude" / "skills" / "goga-tool-obsolete" / "SKILL.md").write_text("# obsolete")
+
+        # Current tool package provides debug skill
+        pkg_dir = _create_tool_package(tmp_path / "pkgs", "goga_tool_debug")
+
+        with (
+            mock.patch.object(_install_mod, "_get_source_dir", return_value=mock_source),
+            mock.patch.object(_install_mod.Path, "home", return_value=mock_home),
+            mock.patch.object(_install_mod, "_download_dsl_spec"),
+            mock.patch.object(
+                _install_mod.importlib.metadata,
+                "packages_distributions",
+                return_value={"goga_tool_debug": ["goga-tool-debug"]},
+            ),
+            mock.patch.object(
+                _install_mod.importlib.util,
+                "find_spec",
+                side_effect=_make_find_spec_side_effect({"goga_tool_debug": pkg_dir}),
+            ),
+        ):
+            result = install(agent="claude", config=config)
+
+        assert result == 0
+        skills_dir = mock_home / ".claude" / "skills"
+        # Obsolete removed by cleanup (runs before tool skill install)
+        assert not (skills_dir / "goga-tool-obsolete").exists()
+        # Current tool skill installed
+        assert (skills_dir / "goga-tool-debug" / "SKILL.md").is_file()
+        # Core skills still present
+        assert (skills_dir / "goga-cell" / "SKILL.md").is_file()
+
+
+class TestTwoPackagesSameSkillName:
+    """Test: two packages with same skill name — first wins, stderr has warning."""
+
+    def test_first_package_wins_on_name_conflict(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # Package 1: goga_tool_debug with skill "debug"
+        pkg1 = tmp_path / "goga_tool_debug"
+        pkg1.mkdir(parents=True)
+        (pkg1 / "__init__.py").write_text("")
+        (pkg1 / "skills" / "debug").mkdir(parents=True)
+        (pkg1 / "skills" / "debug" / "SKILL.md").write_text("# debug from pkg1")
+
+        # Package 2: goga_tool_analyze with skill "analyze" AND "debug"
+        pkg2 = tmp_path / "goga_tool_analyze"
+        pkg2.mkdir(parents=True)
+        (pkg2 / "__init__.py").write_text("")
+        (pkg2 / "skills" / "analyze").mkdir(parents=True)
+        (pkg2 / "skills" / "analyze" / "SKILL.md").write_text("# analyze from pkg2")
+        (pkg2 / "skills" / "debug").mkdir(parents=True)
+        (pkg2 / "skills" / "debug" / "SKILL.md").write_text("# debug from pkg2")
+
+        target = tmp_path / "target"
+        (target / "skills").mkdir(parents=True)
+
+        with (
+            mock.patch.object(
+                _install_mod.importlib.metadata,
+                "packages_distributions",
+                return_value={
+                    "goga_tool_debug": ["goga-tool-debug"],
+                    "goga_tool_analyze": ["goga-tool-analyze"],
+                },
+            ),
+            mock.patch.object(
+                _install_mod.importlib.util,
+                "find_spec",
+                side_effect=_make_find_spec_side_effect(
+                    {"goga_tool_debug": pkg1, "goga_tool_analyze": pkg2}
+                ),
+            ),
+        ):
+            result = _install_tool_skills(target, False)
+
+        # Both packages' unique skills are installed
+        assert "goga-tool-debug" in result
+        assert "goga-tool-analyze" in result
+        # Alphabetically first package (goga_tool_analyze) installs first,
+        # so its content wins for the conflicting skill name
+        content = (target / "skills" / "goga-tool-debug" / "SKILL.md").read_text()
+        assert "pkg2" in content
+        # Warning about the conflict
+        captured = capsys.readouterr()
+        assert "already exists" in captured.err
+
+
+class TestCLIForceOverwriteEndToEnd:
+    """Test: CLI end-to-end — two packages with conflicting skill name.
+    With --force-overwrite, the second package overwrites the first."""
+
+    def test_cli_force_overwrite_replaces_tool_skills(self, tmp_path: Path, monkeypatch) -> None:
+        (tmp_path / ".goga").mkdir()
+        (tmp_path / ".goga" / "config.yml").write_text(
+            "language: python\nbuild:\n  task_executor:\n    agent: claude\n"
+        )
+        monkeypatch.chdir(tmp_path)
+
+        # Package 1: provides "debug" skill
+        pkg1 = _create_tool_package(tmp_path / "pkgs", "goga_tool_debug")
+
+        # Package 2: provides "analyze" and "debug" skills (conflict on "debug")
+        pkg2 = tmp_path / "pkgs" / "goga_tool_analyze"
+        pkg2.mkdir(parents=True)
+        (pkg2 / "__init__.py").write_text("")
+        (pkg2 / "skills" / "analyze").mkdir(parents=True)
+        (pkg2 / "skills" / "analyze" / "SKILL.md").write_text("# analyze")
+        (pkg2 / "skills" / "debug").mkdir(parents=True)
+        (pkg2 / "skills" / "debug" / "SKILL.md").write_text("# debug from pkg2")
+
+        skills_dir = tmp_path / "home" / ".claude" / "skills"
+
+        with (
+            mock.patch("pathlib.Path.home", return_value=tmp_path / "home"),
+            mock.patch("urllib.request.urlopen", return_value=_mock_urlopen_response()),
+            mock.patch.object(
+                _install_mod.importlib.metadata,
+                "packages_distributions",
+                return_value={
+                    "goga_tool_debug": ["goga-tool-debug"],
+                    "goga_tool_analyze": ["goga-tool-analyze"],
+                },
+            ),
+            mock.patch.object(
+                _install_mod.importlib.util,
+                "find_spec",
+                side_effect=_make_find_spec_side_effect(
+                    {"goga_tool_debug": pkg1, "goga_tool_analyze": pkg2}
+                ),
+            ),
+        ):
+            result = CliRunner().invoke(app, ["install", "--force-overwrite"])
+
+        assert result.exit_code == 0
+        # With force_overwrite: alphabetically first (goga_tool_analyze/pkg2) installs
+        # goga-tool-debug first, then goga_tool_debug (pkg1) overwrites it
+        content = (skills_dir / "goga-tool-debug" / "SKILL.md").read_text()
+        assert content == "# debug"
+
+
+class TestCLIWithoutForceOverwrite:
+    """Test: CLI without --force-overwrite — when two packages provide the
+    same skill name, the second package's skill is NOT installed."""
+
+    def test_cli_no_force_preserves_existing_tool_skills(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        (tmp_path / ".goga").mkdir()
+        (tmp_path / ".goga" / "config.yml").write_text(
+            "language: python\nbuild:\n  task_executor:\n    agent: claude\n"
+        )
+        monkeypatch.chdir(tmp_path)
+
+        # Package 1: provides "debug" skill
+        pkg1 = _create_tool_package(tmp_path / "pkgs", "goga_tool_debug")
+
+        # Package 2: provides "analyze" and "debug" skills (conflict on "debug")
+        pkg2 = tmp_path / "pkgs" / "goga_tool_analyze"
+        pkg2.mkdir(parents=True)
+        (pkg2 / "__init__.py").write_text("")
+        (pkg2 / "skills" / "analyze").mkdir(parents=True)
+        (pkg2 / "skills" / "analyze" / "SKILL.md").write_text("# analyze")
+        (pkg2 / "skills" / "debug").mkdir(parents=True)
+        (pkg2 / "skills" / "debug" / "SKILL.md").write_text("# debug from pkg2")
+
+        skills_dir = tmp_path / "home" / ".claude" / "skills"
+
+        with (
+            mock.patch("pathlib.Path.home", return_value=tmp_path / "home"),
+            mock.patch("urllib.request.urlopen", return_value=_mock_urlopen_response()),
+            mock.patch.object(
+                _install_mod.importlib.metadata,
+                "packages_distributions",
+                return_value={
+                    "goga_tool_debug": ["goga-tool-debug"],
+                    "goga_tool_analyze": ["goga-tool-analyze"],
+                },
+            ),
+            mock.patch.object(
+                _install_mod.importlib.util,
+                "find_spec",
+                side_effect=_make_find_spec_side_effect(
+                    {"goga_tool_debug": pkg1, "goga_tool_analyze": pkg2}
+                ),
+            ),
+        ):
+            result = CliRunner().invoke(app, ["install"])
+
+        assert result.exit_code == 0
+        # Alphabetically first (goga_tool_analyze/pkg2) installs goga-tool-debug first,
+        # then goga_tool_debug (pkg1) is skipped (already exists, no force)
+        content = (skills_dir / "goga-tool-debug" / "SKILL.md").read_text()
+        assert "pkg2" in content
+        # Both unique skills installed
+        assert (skills_dir / "goga-tool-analyze" / "SKILL.md").is_file()


### PR DESCRIPTION
Wrap find_spec in try/except for ModuleNotFoundError/ValueError that could crash the entire install. Wrap per-package skill copying in try/except so one bad package doesn't abort remaining packages.

fix: address code review findings for install-tool-packages
- Catch shutil.Error alongside OSError in install() error handler
- Sort packages_distributions() keys for deterministic conflict resolution
- Deduplicate skill names in _install_tool_skills result list
- Add missing edge case tests for empty dict and spec.origin is None
- Update conflict-resolution tests for sorted iteration order

feat: update .usages files for install-tool-packages Add force_overwrite usage example to install-usage.md. Mark all Task 5 checkboxes and success criteria as complete in the plan.

feat: add integration tests for tool skills install and update contract tests feat: add --force-overwrite CLI option to goga install command feat: implement _install_tool_skills for discovering and installing goga_tool_* packages
- Add _install_tool_skills() helper that discovers installed Python packages with goga_tool_ prefix via importlib.metadata, validates their structure, and copies skills with goga-tool- prefix to target directory
- Integrate _install_tool_skills into install() with force_overwrite support
- Add 16 new tests: 5 contract tests and 11 logical tests covering positive, negative, and edge cases feat: add force_overwrite parameter to install() signature Add `force_overwrite: bool = False` to the install function signature in goga/install/install.py. Include contract and logical tests verifying the parameter exists, defaults to False, and accepts both True/False values.